### PR TITLE
Enable closing pop-ups by clicking outside

### DIFF
--- a/src/app/admin/artists/page.tsx
+++ b/src/app/admin/artists/page.tsx
@@ -392,8 +392,8 @@ export default function AdminArtistRegisterPage() {
                     })}
                     {/* 모달 */}
                     {careerModal && (
-                      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-                        <div className="bg-white rounded-xl max-w-lg w-full p-6 relative shadow-2xl">
+                      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setCareerModal(null)}>
+                        <div className="bg-white rounded-xl max-w-lg w-full p-6 relative shadow-2xl" onClick={(e) => e.stopPropagation()}>
                           <button
                             className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl font-bold"
                             onClick={() => setCareerModal(null)}
@@ -454,8 +454,8 @@ export default function AdminArtistRegisterPage() {
       )}
       {/* 영상 상세 모달 */}
       {selectedCareer && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
-          <div className="bg-white rounded-xl max-w-md w-full p-6 relative shadow-2xl flex flex-col items-center">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70" onClick={() => setSelectedCareer(null)}>
+          <div className="bg-white rounded-xl max-w-md w-full p-6 relative shadow-2xl flex flex-col items-center" onClick={(e) => e.stopPropagation()}>
             <button
               className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl font-bold"
               onClick={() => setSelectedCareer(null)}

--- a/src/app/artists/[id]/page.tsx
+++ b/src/app/artists/[id]/page.tsx
@@ -122,8 +122,8 @@ export default function ArtistDetailPage(props: any) {
       <ArtistContactButton artistName={artist.name_ko || "아티스트"} />
       {/* 커리어 상세 모달 */}
       {careerModal && careerModal.career && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-          <div className="bg-white rounded-xl max-w-md w-full mx-4 p-6 relative shadow-2xl flex flex-col items-center max-h-[90vh] overflow-y-auto">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm" onClick={() => setCareerModal(null)}>
+          <div className="bg-white rounded-xl max-w-md w-full mx-4 p-6 relative shadow-2xl flex flex-col items-center max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
             <button
               className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl font-bold z-10"
               onClick={() => setCareerModal(null)}

--- a/src/app/artists/page.tsx
+++ b/src/app/artists/page.tsx
@@ -128,8 +128,8 @@ export default function ArtistListPage() {
       )}
       {/* 경력 모달 */}
       {careerModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="bg-white rounded-xl max-w-lg w-full mx-4 p-6 relative shadow-2xl max-h-[90vh] overflow-hidden">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setCareerModal(null)}>
+          <div className="bg-white rounded-xl max-w-lg w-full mx-4 p-6 relative shadow-2xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
             <button
               className="absolute top-3 right-3 text-gray-500 hover:text-black text-xl font-bold z-10"
               onClick={() => setCareerModal(null)}


### PR DESCRIPTION
Allow modals on artist pages to be closed by clicking outside them to improve user experience.